### PR TITLE
moving ROS-specific KDL Lua code to rtt_kdl_conversions

### DIFF
--- a/kdl_lua/CMakeLists.txt
+++ b/kdl_lua/CMakeLists.txt
@@ -7,5 +7,5 @@ find_package(OROCOS-RTT REQUIRED)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 
 orocos_generate_package(
-  DEPENDS_TARGETS ocl kdl_typekit rtt_kdl_conversions
+  DEPENDS_TARGETS ocl kdl_typekit 
 )

--- a/kdl_lua/lua/kdlutils.lua
+++ b/kdl_lua/lua/kdlutils.lua
@@ -65,13 +65,3 @@ function add_delta_rot(r,v,dt)
    return rtt.provides("KDL"):provides("Rotation"):addDelta(r,v,dt)
 end
 
-function frame_to_msg(f)
-   msg = rtt.Variable("geometry_msgs/Pose")
-   rtt.provides("KDL"):FrameToMsg(f,msg)
-   return msg
-end
-function msg_to_frame(msg)
-   f = rtt.Variable("KDL/Frame")
-   rtt.provides("KDL"):MsgToFrame(msg,f)
-   return f
-end

--- a/kdl_lua/package.xml
+++ b/kdl_lua/package.xml
@@ -17,19 +17,16 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- Dependencies needed to compile this package. -->
-  <build_depend>ocl</build_depend>
-  <build_depend>kdl_typekit</build_depend>
-  <build_depend>rtt_kdl_conversions</build_depend>
+  <build_depend>rtt</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
+  <run_depend>rtt</run_depend>
   <run_depend>ocl</run_depend>
   <run_depend>kdl_typekit</run_depend>
-  <run_depend>rtt_kdl_conversions</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>ocl</test_depend> -->
   <!-- <test_depend>kdl_typekit</test_depend> -->
-  <!-- <test_depend>rtt_kdl_conversions</test_depend> -->
 
   <export>
 

--- a/rtt_kdl_conversions/lua/kdl_conversions.lua
+++ b/rtt_kdl_conversions/lua/kdl_conversions.lua
@@ -1,0 +1,15 @@
+local rttlib = require "rttlib"
+local rtt = rtt
+module("kdl_conversions")
+
+function frame_to_msg(f)
+   msg = rtt.Variable("geometry_msgs/Pose")
+   rtt.provides("KDL"):FrameToMsg(f,msg)
+   return msg
+end
+function msg_to_frame(msg)
+   f = rtt.Variable("KDL/Frame")
+   rtt.provides("KDL"):MsgToFrame(msg,f)
+   return f
+end
+


### PR DESCRIPTION
This will allow us to move the rtt_kdl_conversions package to the rtt_ros_integration repo and make this one ROS-independent. 
