### PR TITLE
kdl_typekit: removing problem-causing kdl dependency

### DIFF
--- a/kdl_typekit/CMakeLists.txt
+++ b/kdl_typekit/CMakeLists.txt
@@ -46,5 +46,5 @@ endif()
 add_subdirectory(src/corba)
 
 orocos_generate_package(
-  orocos-kdl
+  DEPENDS orocos-kdl
 )


### PR DESCRIPTION
@meyerj @smits
I'm a little confused about when one is supposed use the `DEPENDS` argument in `orocos_generate_package`. I thought it was just for RTT-based packages, but at some point it was added to `kdl_typekit` to depend on KDL, which is not an "orocos package". I've removed it here, along with the two other ROS packages which this package no longer needs.

Specifically in this case,  even if the KDL package in orocos_kinematics_dynamics is named "kdl", when putting "kdl" into the `orocos_generate_package(DEPENDS)` arguments, it causes the system to look for `kdl.pc` which isn't supposed to be generated.
