### PR TITLE
kdl_typekit: added index operators for Vector, Wrench and Twist

### DIFF
--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadTwistTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Twist>("KDL.Twist") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Twist,6>("KDL.Twist") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Twist > >("KDL.Twist[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadVectorTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Vector>("KDL.Vector") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Vector,3>("KDL.Vector") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Vector > >("KDL.Vector[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -5,7 +5,7 @@ namespace KDL{
   using namespace RTT;
 
   void loadWrenchTypes(){
-    RTT::types::Types()->addType( new KDLTypeInfo<Wrench>("KDL.Wrench") );
+    RTT::types::Types()->addType( new KDLVectorTypeInfo<Wrench,6>("KDL.Wrench") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Wrench > >("KDL.Wrench[]") );
   };
 }  

--- a/kdl_typekit/test/CMakeLists.txt
+++ b/kdl_typekit/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-find_package(OROCOS-RTT REQUIRED rtt-marshalling)
+find_package(OROCOS-RTT REQUIRED rtt-marshalling rtt-scripting)
 
 orocos_use_package(ocl-deployment)
 include_directories(${ocl-deployment_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src)
@@ -14,13 +14,20 @@ target_link_libraries(typekit_test
   ${PROJECT_NAME}
   pthread)
 
+catkin_add_gtest(typekit_scripting_test typekit_scripting_test.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(typekit_scripting_test 
+  ${orocos_kdl_LIBRARIES}
+  ${OROCOS-RTT_RTT_LIBRARIES}
+  ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY} 
+  ${PROJECT_NAME}
+  pthread)
+
 if(OROCOS-RTT_CORBA_FOUND)
 catkin_add_gtest(typekit_corba_test typekit_corba_test.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(typekit_corba_test 
   ${orocos_kdl_LIBRARIES}
   ${USE_OROCOS_LIBRARIES}
   ${OROCOS-RTT_RTT_LIBRARIES}
-  ${OROCOS-RTT_RTT-MARSHALLING_LIBRARY}
   ${OROCOS-RTT_CORBA_LIBRARIES}
   ${PROJECT_NAME}
   pthread)

--- a/kdl_typekit/test/typekit-test.ops
+++ b/kdl_typekit/test/typekit-test.ops
@@ -1,0 +1,42 @@
+program vector_test {
+ var KDL.Vector v1;
+ var KDL.Vector v2;
+ var KDL.Vector v3;
+ 
+ //Test accessors
+ v1.X = 1.
+ v1.Y = 2.
+ v1.Z = 3.
+ v2[0] = 10.
+ v2[1] = 20.
+ v2[2] = 30.
+ if ( v1[0] != 1.) then throw()
+ if ( v1[1] != 2.) then throw()
+ if ( v1[2] != 3.) then throw()
+ if ( v1[3] != 0.) then throw()
+ if ( v1[-1] != 0.) then throw()
+ 
+ if ( v2.X != 10.) then throw()
+ if ( v2.Y != 20.) then throw()
+ if ( v2.Z != 30.) then throw()
+ 
+ //Test operations
+ v3 = v2 + v1
+ if ( v3 != v2 + v1) then throw()
+ if ( v2 == v3 ) then throw()
+ v3 = v2 - v1
+ if ( v3 != v2 - v1) then throw()
+ v3 = v1 * 2
+ if ( v3[0] != v1[0] * 2) then throw()
+ if ( v3[1] != v1[1] * 2) then throw()
+ if ( v3[2] != v1[2] * 2) then throw()
+ v3 = v1 / 2
+ if ( v3[0] != v1[0] / 2) then throw()
+ if ( v3[1] != v1[1] / 2) then throw()
+ if ( v3[2] != v1[2] / 2) then throw()
+ 
+}
+
+program rotation_test {
+ var KDL.Rotation r;
+ }

--- a/kdl_typekit/test/typekit_scripting_test.cpp
+++ b/kdl_typekit/test/typekit_scripting_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <rtt/os/main.h>
+#include <rtt/plugin/PluginLoader.hpp>
+#include <rtt/scripting/ScriptingService.hpp>
+#include <rtt/TaskContext.hpp>
+
+
+void throw_function() {
+    throw std::exception();
+}
+
+class KDLPluginScriptingTest : public testing::Test {
+
+protected:
+    KDLPluginScriptingTest():
+        tc("test")
+    {
+    }
+
+    virtual void SetUp() {
+        ASSERT_TRUE(RTT::plugin::PluginLoader::Instance()->loadTypekit("kdl_typekit",RTT::plugin::PluginLoader::Instance()->getPluginPath())) << "Failed to load kdl typekit";
+        ASSERT_TRUE(tc.loadService("scripting")) << "Unable to load scripting service";
+        scripting = boost::dynamic_pointer_cast<RTT::scripting::ScriptingService>( tc.provides()->getService("scripting") );
+        ASSERT_TRUE(scripting) << "Failed to get loaded scripting service";
+
+        tc.addOperation("throw",&throw_function);
+        tc.setPeriod(0.01);
+        ASSERT_TRUE(scripting->loadPrograms("./typekit-test.ops",false)) << "Failed to load test program";
+        ASSERT_TRUE(tc.start()) << "Failed to start TaskContext";
+    }
+    virtual void TearDown() {
+    }
+    
+    RTT::TaskContext tc;
+    RTT::scripting::ScriptingService::shared_ptr scripting;
+};
+
+TEST_F(KDLPluginScriptingTest, ScriptTest) {
+    RTT::scripting::ProgramInterfacePtr program = scripting->getProgram("vector_test");
+    ASSERT_TRUE(program) << "Failed to get program";
+    ASSERT_TRUE(program->start());
+    while(program->isRunning()) {;
+        ASSERT_FALSE(program->inError()) << "program failed on line " << program->getLineNumber();
+        usleep(1000);
+    }
+    ASSERT_FALSE(program->inError()) << "Failed on line " << program->getLineNumber();
+}
+
+int ORO_main(int argc, char **argv){
+    testing::InitGoogleTest(&argc,argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
This PR allows to additionally to the names use [] operators in scripting for Vector, Twist and Wrench:
````
var KDL.Twist t;
v[3] = 1.
v.rot.X //(==1.)
````
Signed-off-by: Ruben Smits <ruben.smits@intermodalics.eu>