### PR TITLE
kdl_typekit: fix extern declare, explicit instantiate mechanism

### DIFF
--- a/kdl_typekit/src/kdlTypekitChain.cpp
+++ b/kdl_typekit/src/kdlTypekitChain.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Chain >;
+template class RTT::internal::AssignableDataSource< ::KDL::Chain >;
+template class RTT::internal::ValueDataSource< ::KDL::Chain >;
+template class RTT::internal::ConstantDataSource< ::KDL::Chain >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Chain >;
+template class RTT::base::ChannelElement< ::KDL::Chain >;
+template class RTT::OutputPort< ::KDL::Chain >;
+template class RTT::InputPort< ::KDL::Chain >;
+template class RTT::Property< ::KDL::Chain >;
+template class RTT::Attribute< ::KDL::Chain >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitFrame.cpp
+++ b/kdl_typekit/src/kdlTypekitFrame.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Frame >;
+template class RTT::internal::AssignableDataSource< ::KDL::Frame >;
+template class RTT::internal::ValueDataSource< ::KDL::Frame >;
+template class RTT::internal::ConstantDataSource< ::KDL::Frame >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Frame >;
+template class RTT::base::ChannelElement< ::KDL::Frame >;
+template class RTT::OutputPort< ::KDL::Frame >;
+template class RTT::InputPort< ::KDL::Frame >;
+template class RTT::Property< ::KDL::Frame >;
+template class RTT::Attribute< ::KDL::Frame >;
+template class RTT::internal::DataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Frame> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Frame> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Frame> >;
+template class RTT::OutputPort< std::vector<KDL::Frame> >;
+template class RTT::InputPort< std::vector<KDL::Frame> >;
+template class RTT::Property< std::vector<KDL::Frame> >;
+template class RTT::Attribute< std::vector<KDL::Frame> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJacobian.cpp
+++ b/kdl_typekit/src/kdlTypekitJacobian.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Jacobian >;
+template class RTT::internal::AssignableDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ValueDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ConstantDataSource< ::KDL::Jacobian >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Jacobian >;
+template class RTT::base::ChannelElement< ::KDL::Jacobian >;
+template class RTT::OutputPort< ::KDL::Jacobian >;
+template class RTT::InputPort< ::KDL::Jacobian >;
+template class RTT::Property< ::KDL::Jacobian >;
+template class RTT::Attribute< ::KDL::Jacobian >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJntArray.cpp
+++ b/kdl_typekit/src/kdlTypekitJntArray.cpp
@@ -1,5 +1,17 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::JntArray >;
+template class RTT::internal::AssignableDataSource< ::KDL::JntArray >;
+template class RTT::internal::ValueDataSource< ::KDL::JntArray >;
+template class RTT::internal::ConstantDataSource< ::KDL::JntArray >;
+template class RTT::internal::ReferenceDataSource< ::KDL::JntArray >;
+template class RTT::base::ChannelElement< ::KDL::JntArray >;
+template class RTT::OutputPort< ::KDL::JntArray >;
+template class RTT::InputPort< ::KDL::JntArray >;
+template class RTT::Property< ::KDL::JntArray >;
+template class RTT::Attribute< ::KDL::JntArray >;
+
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitJoint.cpp
+++ b/kdl_typekit/src/kdlTypekitJoint.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Joint >;
+template class RTT::internal::AssignableDataSource< ::KDL::Joint >;
+template class RTT::internal::ValueDataSource< ::KDL::Joint >;
+template class RTT::internal::ConstantDataSource< ::KDL::Joint >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Joint >;
+template class RTT::base::ChannelElement< ::KDL::Joint >;
+template class RTT::OutputPort< ::KDL::Joint >;
+template class RTT::InputPort< ::KDL::Joint >;
+template class RTT::Property< ::KDL::Joint >;
+template class RTT::Attribute< ::KDL::Joint >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitRotation.cpp
+++ b/kdl_typekit/src/kdlTypekitRotation.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Rotation >;
+template class RTT::internal::AssignableDataSource< ::KDL::Rotation >;
+template class RTT::internal::ValueDataSource< ::KDL::Rotation >;
+template class RTT::internal::ConstantDataSource< ::KDL::Rotation >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Rotation >;
+template class RTT::base::ChannelElement< ::KDL::Rotation >;
+template class RTT::OutputPort< ::KDL::Rotation >;
+template class RTT::InputPort< ::KDL::Rotation >;
+template class RTT::Property< ::KDL::Rotation >;
+template class RTT::Attribute< ::KDL::Rotation >;
+template class RTT::internal::DataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Rotation> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Rotation> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Rotation> >;
+template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+template class RTT::InputPort< std::vector<KDL::Rotation> >;
+template class RTT::Property< std::vector<KDL::Rotation> >;
+template class RTT::Attribute< std::vector<KDL::Rotation> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitSegment.cpp
+++ b/kdl_typekit/src/kdlTypekitSegment.cpp
@@ -1,5 +1,16 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Segment >;
+template class RTT::internal::AssignableDataSource< ::KDL::Segment >;
+template class RTT::internal::ValueDataSource< ::KDL::Segment >;
+template class RTT::internal::ConstantDataSource< ::KDL::Segment >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Segment >;
+template class RTT::base::ChannelElement< ::KDL::Segment >;
+template class RTT::OutputPort< ::KDL::Segment >;
+template class RTT::InputPort< ::KDL::Segment >;
+template class RTT::Property< ::KDL::Segment >;
+template class RTT::Attribute< ::KDL::Segment >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Twist >;
+template class RTT::internal::AssignableDataSource< ::KDL::Twist >;
+template class RTT::internal::ValueDataSource< ::KDL::Twist >;
+template class RTT::internal::ConstantDataSource< ::KDL::Twist >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Twist >;
+template class RTT::base::ChannelElement< ::KDL::Twist >;
+template class RTT::OutputPort< ::KDL::Twist >;
+template class RTT::InputPort< ::KDL::Twist >;
+template class RTT::Property< ::KDL::Twist >;
+template class RTT::Attribute< ::KDL::Twist >;
+template class RTT::internal::DataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Twist> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Twist> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Twist> >;
+template class RTT::OutputPort< std::vector<KDL::Twist> >;
+template class RTT::InputPort< std::vector<KDL::Twist> >;
+template class RTT::Property< std::vector<KDL::Twist> >;
+template class RTT::Attribute< std::vector<KDL::Twist> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitTypes.hpp
+++ b/kdl_typekit/src/kdlTypekitTypes.hpp
@@ -10,7 +10,6 @@
 #include <kdl/jntarray.hpp>
 
 
-
 // This is a hack. We include it unconditionally as it may be required by some
 // typekits *and* it is a standard header. Ideally, we would actually check if
 // some of the types need std::vector.
@@ -29,10 +28,13 @@
     extern template class RTT::internal::ConstantDataSource< ::KDL::Frame >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Frame >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Frame >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Frame >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Frame >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Frame >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -67,10 +69,13 @@ a & make_nvp("M", b.M);
     extern template class RTT::internal::ConstantDataSource< ::KDL::Rotation >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Rotation >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Rotation >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Rotation >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Rotation >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Rotation >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -111,10 +116,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Twist >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Twist >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Twist >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Twist >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Twist >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Twist >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -150,10 +158,13 @@ a & make_nvp("rot", b.rot);
     extern template class RTT::internal::ConstantDataSource< ::KDL::Vector >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Vector >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Vector >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Vector >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Vector >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Vector >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -189,10 +200,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Wrench >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Wrench >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Wrench >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Wrench >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Wrench >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Wrench >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -226,10 +240,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Chain >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Chain >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Chain >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Chain >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Chain >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Chain >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -259,10 +276,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Joint >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Joint >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Joint >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Joint >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Joint >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Joint >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -292,10 +312,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Segment >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Segment >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Segment >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Segment >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Segment >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Segment >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -324,10 +347,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::Jacobian >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::Jacobian >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::Jacobian >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::Jacobian >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::Jacobian >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::Jacobian >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -357,10 +383,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< ::KDL::JntArray >;
     extern template class RTT::internal::ReferenceDataSource< ::KDL::JntArray >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< ::KDL::JntArray >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< ::KDL::JntArray >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< ::KDL::JntArray >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< ::KDL::JntArray >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -396,10 +425,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Rotation> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Rotation> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Rotation> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Rotation> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Rotation> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -433,10 +465,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Vector> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Vector> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Vector> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Vector> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Vector> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Vector> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -471,10 +506,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Frame> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Frame> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Frame> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Frame> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Frame> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Frame> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -509,10 +547,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Twist> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Twist> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Twist> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Twist> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Twist> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Twist> >;
 #endif
 #ifdef ORO_PROPERTY_HPP
@@ -547,10 +588,13 @@ namespace boost
     extern template class RTT::internal::ConstantDataSource< std::vector<KDL::Wrench> >;
     extern template class RTT::internal::ReferenceDataSource< std::vector<KDL::Wrench> >;
 #endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+#ifdef ORO_CHANNEL_ELEMENT_HPP
+    extern template class RTT::base::ChannelElement< std::vector<KDL::Wrench> >;
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< std::vector<KDL::Wrench> >;
 #endif
 #ifdef ORO_PROPERTY_HPP

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Vector >;
+template class RTT::internal::AssignableDataSource< ::KDL::Vector >;
+template class RTT::internal::ValueDataSource< ::KDL::Vector >;
+template class RTT::internal::ConstantDataSource< ::KDL::Vector >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Vector >;
+template class RTT::base::ChannelElement< ::KDL::Vector >;
+template class RTT::OutputPort< ::KDL::Vector >;
+template class RTT::InputPort< ::KDL::Vector >;
+template class RTT::Property< ::KDL::Vector >;
+template class RTT::Attribute< ::KDL::Vector >;
+template class RTT::internal::DataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Vector> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Vector> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Vector> >;
+template class RTT::OutputPort< std::vector<KDL::Vector> >;
+template class RTT::InputPort< std::vector<KDL::Vector> >;
+template class RTT::Property< std::vector<KDL::Vector> >;
+template class RTT::Attribute< std::vector<KDL::Vector> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -1,5 +1,26 @@
 #include "kdlTypekit.hpp"
 
+template class RTT::internal::DataSource< ::KDL::Wrench >;
+template class RTT::internal::AssignableDataSource< ::KDL::Wrench >;
+template class RTT::internal::ValueDataSource< ::KDL::Wrench >;
+template class RTT::internal::ConstantDataSource< ::KDL::Wrench >;
+template class RTT::internal::ReferenceDataSource< ::KDL::Wrench >;
+template class RTT::base::ChannelElement< KDL::Wrench >;
+template class RTT::OutputPort< ::KDL::Wrench >;
+template class RTT::InputPort< ::KDL::Wrench >;
+template class RTT::Property< ::KDL::Wrench >;
+template class RTT::Attribute< ::KDL::Wrench >;
+template class RTT::internal::DataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::AssignableDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ValueDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ConstantDataSource< std::vector<KDL::Wrench> >;
+template class RTT::internal::ReferenceDataSource< std::vector<KDL::Wrench> >;
+template class RTT::base::ChannelElement< std::vector<KDL::Wrench> >;
+template class RTT::OutputPort< std::vector<KDL::Wrench> >;
+template class RTT::InputPort< std::vector<KDL::Wrench> >;
+template class RTT::Property< std::vector<KDL::Wrench> >;
+template class RTT::Attribute< std::vector<KDL::Wrench> >;
+
 namespace KDL{
   using namespace std;
   using namespace RTT;


### PR DESCRIPTION
We forgot the explicit instantiation, also added the channelelement type

Signed-off-by: Ruben Smits <ruben.smits@intermodalics.eu>