### PR TITLE
kdl_typekit: remove unused Boost serialization methods for vectors

### DIFF
--- a/kdl_typekit/src/kdlTypekitTypes.hpp
+++ b/kdl_typekit/src/kdlTypekitTypes.hpp
@@ -441,21 +441,6 @@ namespace boost
     extern template class RTT::Attribute< std::vector<KDL::Rotation> >;
 #endif
 
-
-namespace boost
-{
-    namespace serialization
-    {
-        template<typename Archive>
-        void serialize(Archive& a, std::vector<KDL::Rotation>& b, unsigned int version)
-        {
-            using boost::serialization::make_nvp;
-            for(unsigned int i=0; i < b.size(); i++){
-              boost::serialization::serialize(a, b[i], version);
-            }
-        }
-    }
-}
 #ifdef CORELIB_DATASOURCE_HPP
     extern template class RTT::internal::DataSource< std::vector<KDL::Vector> >;
     extern template class RTT::internal::AssignableDataSource< std::vector<KDL::Vector> >;
@@ -481,22 +466,6 @@ namespace boost
     extern template class RTT::Attribute< std::vector<KDL::Vector> >;
 #endif
 
-
-namespace boost
-{
-    namespace serialization
-    {
-        template<typename Archive>
-        void serialize(Archive& a, std::vector<KDL::Vector>& b, unsigned int version)
-        {
-            using boost::serialization::make_nvp;
-            for(unsigned int i=0; i < b.size(); i++){
-              boost::serialization::serialize(a, b[i], version);
-
-            }
-        }
-    }
-}
 #ifdef CORELIB_DATASOURCE_HPP
     extern template class RTT::internal::DataSource< std::vector<KDL::Frame> >;
     extern template class RTT::internal::AssignableDataSource< std::vector<KDL::Frame> >;
@@ -522,22 +491,6 @@ namespace boost
     extern template class RTT::Attribute< std::vector<KDL::Frame> >;
 #endif
 
-
-namespace boost
-{
-    namespace serialization
-    {
-        template<typename Archive>
-        void serialize(Archive& a, std::vector<KDL::Frame>& b, unsigned int version)
-        {
-            using boost::serialization::make_nvp;
-            for(unsigned int i=0; i < b.size(); i++){
-              boost::serialization::serialize(a, b[i], version);
-
-            }
-        }
-    }
-}
 #ifdef CORELIB_DATASOURCE_HPP
     extern template class RTT::internal::DataSource< std::vector<KDL::Twist> >;
     extern template class RTT::internal::AssignableDataSource< std::vector<KDL::Twist> >;
@@ -563,22 +516,6 @@ namespace boost
     extern template class RTT::Attribute< std::vector<KDL::Twist> >;
 #endif
 
-
-namespace boost
-{
-    namespace serialization
-    {
-        template<typename Archive>
-        void serialize(Archive& a, std::vector<KDL::Twist>& b, unsigned int version)
-        {
-            using boost::serialization::make_nvp;
-            for(unsigned int i=0; i < b.size(); i++){
-              boost::serialization::serialize(a, b[i], version);
-
-            }
-        }
-    }
-}
 #ifdef CORELIB_DATASOURCE_HPP
     extern template class RTT::internal::DataSource< std::vector<KDL::Wrench> >;
     extern template class RTT::internal::AssignableDataSource< std::vector<KDL::Wrench> >;
@@ -604,21 +541,5 @@ namespace boost
     extern template class RTT::Attribute< std::vector<KDL::Wrench> >;
 #endif
 
-
-namespace boost
-{
-    namespace serialization
-    {
-        template<typename Archive>
-        void serialize(Archive& a, std::vector<KDL::Wrench>& b, unsigned int version)
-        {
-            using boost::serialization::make_nvp;
-            for(unsigned int i=0; i < b.size(); i++){
-              boost::serialization::serialize(a, b[i], version);
-
-            }
-        }
-    }
-}
 #endif
 


### PR DESCRIPTION
Boost serialization already knows how to handle various container types
(see http://www.boost.org/doc/libs/1_54_0/libs/serialization/doc/tutorial.html#stl).

The specialized variant of the `serialize()` method for vectors will not be used by RTT's class [SequenceTypeInfo](https://github.com/orocos-toolchain/rtt/blob/master/rtt/types/SequenceTypeInfo.hpp) and is not required.
