### PR TITLE
Handle typekit packages as non-catkin packages

### DIFF
--- a/eigen_typekit/package.xml
+++ b/eigen_typekit/package.xml
@@ -14,4 +14,9 @@
   <build_depend>cmake_modules</build_depend>
 
   <run_depend>rtt</run_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
 </package>

--- a/kdl_typekit/package.xml
+++ b/kdl_typekit/package.xml
@@ -28,4 +28,9 @@
   <!-- <test_depend>rtt</test_depend> -->
   <!-- <test_depend>ocl</test_depend> -->
   <!-- <test_depend>orocos_kdl</test_depend> -->
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
 </package>


### PR DESCRIPTION
kdl_typekit and eigen_typekit currently do not follow catkin conventions. Although `catkin_package()` is called internally by the `orocos_generate_package()` cmake macro, the typekits cannot be used without installation from devel-space because typekit headers cannot be found in dependent packages.

This patch adds the build_type cmake declaration to package.xml, so that the packages can be at least built with catkin_make_isolated or catkin_tools, which install the headers and libraries in the devel-space (unless explicitly invoked with `--install` or `catkin config --install`).

A better approach would probably be to rename and move the headers provided by the packages into a `include/orocos` directory with subfolders following the naming conventions of the install-space. If such a directory exists, orocos_generate_package() will automatically pick it up and make it available to other Orocos packages in the same devel-space and/or cmake project (see [UseOROCOS-RTT.cmake:902](https://github.com/orocos-toolchain/rtt/blob/master/UseOROCOS-RTT.cmake#L902)).
