### PR TITLE
kdl_typekit: add CArrayTypeInfo variants to the typekit to support fixed-size arrays

### DIFF
--- a/kdl_typekit/src/kdlTypekit.hpp
+++ b/kdl_typekit/src/kdlTypekit.hpp
@@ -51,6 +51,8 @@
 #include <rtt/types/TemplateTypeInfo.hpp>
 #include <rtt/types/SequenceTypeInfo.hpp>
 #include <rtt/types/StructTypeInfo.hpp>
+#include <rtt/types/carray.hpp>
+#include <rtt/types/CArrayTypeInfo.hpp>
 #include <rtt/types/Operators.hpp>
 #include <rtt/types/OperatorTypes.hpp>
 #include <rtt/internal/mystd.hpp>

--- a/kdl_typekit/src/kdlTypekitChain.cpp
+++ b/kdl_typekit/src/kdlTypekitChain.cpp
@@ -18,5 +18,6 @@ namespace KDL{
   void loadChainTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Chain>("KDL.Chain") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Chain > >("KDL.Chain[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Chain > >("KDL.cChain[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitFrame.cpp
+++ b/kdl_typekit/src/kdlTypekitFrame.cpp
@@ -28,6 +28,7 @@ namespace KDL{
   void loadFrameTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Frame>("KDL.Frame") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Frame > >("KDL.Frame[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Frame > >("KDL.cFrame[]") );
   };
 
 }  

--- a/kdl_typekit/src/kdlTypekitJacobian.cpp
+++ b/kdl_typekit/src/kdlTypekitJacobian.cpp
@@ -18,6 +18,7 @@ namespace KDL{
   void loadJacobianTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Jacobian>("KDL.Jacobian") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Jacobian > >("KDL.Jacobian[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Jacobian > >("KDL.cJacobian[]") );
   };
 
 }

--- a/kdl_typekit/src/kdlTypekitJntArray.cpp
+++ b/kdl_typekit/src/kdlTypekitJntArray.cpp
@@ -183,5 +183,6 @@ namespace KDL{
     void loadJntArrayTypes(){
         RTT::types::Types()->addType( new JntArrayTypeInfo() );
         RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< JntArray > >("KDL.JntArray[]") );
+        RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< JntArray > >("KDL.cJntArray[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitJoint.cpp
+++ b/kdl_typekit/src/kdlTypekitJoint.cpp
@@ -18,5 +18,6 @@ namespace KDL{
   void loadJointTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Joint>("KDL.Joint") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Joint > >("KDL.Joint[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Joint > >("KDL.cJoint[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitRotation.cpp
+++ b/kdl_typekit/src/kdlTypekitRotation.cpp
@@ -28,5 +28,6 @@ namespace KDL{
   void loadRotationTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Rotation>("KDL.Rotation") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Rotation > >("KDL.Rotation[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Rotation > >("KDL.cRotation[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitSegment.cpp
+++ b/kdl_typekit/src/kdlTypekitSegment.cpp
@@ -18,5 +18,6 @@ namespace KDL{
   void loadSegmentTypes(){
     RTT::types::Types()->addType( new KDLTypeInfo<Segment>("KDL.Segment") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Segment > >("KDL.Segment[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Segment > >("KDL.cSegment[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -28,5 +28,6 @@ namespace KDL{
   void loadTwistTypes(){
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Twist,6>("KDL.Twist") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Twist > >("KDL.Twist[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Twist > >("KDL.cTwist[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -28,5 +28,6 @@ namespace KDL{
   void loadVectorTypes(){
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Vector,3>("KDL.Vector") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Vector > >("KDL.Vector[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Vector > >("KDL.cVector[]") );
   };
 }  

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -28,5 +28,6 @@ namespace KDL{
   void loadWrenchTypes(){
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Wrench,6>("KDL.Wrench") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Wrench > >("KDL.Wrench[]") );
+    RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Wrench > >("KDL.cWrench[]") );
   };
 }  


### PR DESCRIPTION
This PR adds fixes-size array support to the KDL typekit:
```cpp
struct MyStruct {
  boost::array<KDL::Vector, 3> three_vectors;
  // or
  KDL::Vector three_vectors[3];
}

RTT::types::Types()->addType( new RTT::types::StructTypeInfo<MyStruct>("MyStruct") );
```

This feature is required to fully support nesting native KDL types in other ROS messages and subsequently generate a typekit for it using [rtt_roscomm](https://github.com/orocos/rtt_ros_integration/tree/indigo-devel/rtt_roscomm). See https://github.com/orocos/kdl_msgs. Example:
```
# foo_msgs/MyStruct.msg
kdl_msgs/Vector[3] three_vectors
```