### PR TITLE
Fixed extra semicolon warnings when compiling in pedantic mode

### DIFF
--- a/eigen_typekit/corba/CorbaEigenConversion.hpp
+++ b/eigen_typekit/corba/CorbaEigenConversion.hpp
@@ -122,6 +122,6 @@ namespace RTT
 
     };
 
-  };//namespace corba
-};//namespace RTT
+  } //namespace corba
+} //namespace RTT
 

--- a/kdl_typekit/src/corba/CorbaKDLConversion.hpp
+++ b/kdl_typekit/src/corba/CorbaKDLConversion.hpp
@@ -396,6 +396,6 @@ namespace RTT
         return true;
       }
     };
-  };//namespace corba
-};//namespace RTT
+  } //namespace corba
+} //namespace RTT
 

--- a/kdl_typekit/src/kdlTypekit.hpp
+++ b/kdl_typekit/src/kdlTypekit.hpp
@@ -88,7 +88,7 @@ namespace KDL
       if (index >= size || index < 0)
           return internal::NA<double&>::na();
       return cont[index];
-  };
+  }
 
   /**
    * Returns a copy to one item in an STL container.
@@ -103,7 +103,7 @@ namespace KDL
       if (index >= size || index < 0)
           return internal::NA<double>::na();
       return cont[index];
-  };
+  }
 
   /**
    * KDL RTT bindings
@@ -159,24 +159,24 @@ namespace KDL
   };
 
   /**
-     * Template class used for Frame, Rotation
-     */
-    template<class KDLType>
-    struct KDLTypeInfo
-      : public StructTypeInfo<KDLType,true>
-    {
-      KDLTypeInfo(std::string name) : StructTypeInfo<KDLType,true>(name) {}
+   * Template class used for Frame, Rotation
+   */
+  template<class KDLType>
+  struct KDLTypeInfo
+    : public StructTypeInfo<KDLType,true>
+  {
+    KDLTypeInfo(std::string name) : StructTypeInfo<KDLType,true>(name) {}
 
-      virtual bool decomposeTypeImpl(const KDLType& source, PropertyBag& targetbag ) const {
-        decomposeProperty( source, targetbag );
-        return true;
-      }
+    virtual bool decomposeTypeImpl(const KDLType& source, PropertyBag& targetbag ) const {
+      decomposeProperty( source, targetbag );
+      return true;
+    }
 
-      virtual bool composeTypeImpl(const PropertyBag& source, KDLType& result) const {
-        return composeProperty( source, result );
-      }
+    virtual bool composeTypeImpl(const PropertyBag& source, KDLType& result) const {
+      return composeProperty( source, result );
+    }
 
-    };
+  };
 
   /**
    * The single global instance of the KDL Typekit.

--- a/kdl_typekit/src/kdlTypekitChain.cpp
+++ b/kdl_typekit/src/kdlTypekitChain.cpp
@@ -19,5 +19,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Chain>("KDL.Chain") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Chain > >("KDL.Chain[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Chain > >("KDL.cChain[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitConstructors.cpp
+++ b/kdl_typekit/src/kdlTypekitConstructors.cpp
@@ -4,27 +4,27 @@ namespace KDL{
   Frame framevr( const Vector& v, const Rotation& r )
   {
           return Frame( r, v );
-  };
+  }
   Frame framerv( const Rotation& r, const Vector& v )
   {
           return Frame( r, v );
-  };
+  }
   
   
   Wrench wrenchft( const Vector& force, const Vector& torque )
   {
           return Wrench( force, torque );
-  };
+  }
   
   Twist twistvw( const Vector& trans, const Vector& rot )
   {
           return Twist( trans, rot );
-  };
+  }
   
   Vector vectorxyz( double a, double b, double c )
   {
           return Vector( a, b, c );
-  };
+  }
   
   
   // INDEXING
@@ -172,7 +172,7 @@ namespace KDL{
     Rotation rotationAngleAxis( const Vector& axis, double angle )
     {
         return Rotation::Rot(axis, angle);
-    };
+    }
 
     bool KDLTypekitPlugin::loadConstructors()
     {

--- a/kdl_typekit/src/kdlTypekitFrame.cpp
+++ b/kdl_typekit/src/kdlTypekitFrame.cpp
@@ -29,6 +29,6 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Frame>("KDL.Frame") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Frame > >("KDL.Frame[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Frame > >("KDL.cFrame[]") );
-  };
+  }
 
 }  

--- a/kdl_typekit/src/kdlTypekitJacobian.cpp
+++ b/kdl_typekit/src/kdlTypekitJacobian.cpp
@@ -19,7 +19,7 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Jacobian>("KDL.Jacobian") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Jacobian > >("KDL.Jacobian[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Jacobian > >("KDL.cJacobian[]") );
-  };
+  }
 
 }
 

--- a/kdl_typekit/src/kdlTypekitJntArray.cpp
+++ b/kdl_typekit/src/kdlTypekitJntArray.cpp
@@ -180,9 +180,10 @@ namespace KDL{
         }
 
     };
+
     void loadJntArrayTypes(){
         RTT::types::Types()->addType( new JntArrayTypeInfo() );
         RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< JntArray > >("KDL.JntArray[]") );
         RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< JntArray > >("KDL.cJntArray[]") );
-  };
+    }
 }  

--- a/kdl_typekit/src/kdlTypekitJoint.cpp
+++ b/kdl_typekit/src/kdlTypekitJoint.cpp
@@ -19,5 +19,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Joint>("KDL.Joint") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Joint > >("KDL.Joint[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Joint > >("KDL.cJoint[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitRotation.cpp
+++ b/kdl_typekit/src/kdlTypekitRotation.cpp
@@ -29,5 +29,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Rotation>("KDL.Rotation") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Rotation > >("KDL.Rotation[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Rotation > >("KDL.cRotation[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitSegment.cpp
+++ b/kdl_typekit/src/kdlTypekitSegment.cpp
@@ -19,5 +19,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLTypeInfo<Segment>("KDL.Segment") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Segment > >("KDL.Segment[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Segment > >("KDL.cSegment[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitTwist.cpp
+++ b/kdl_typekit/src/kdlTypekitTwist.cpp
@@ -29,5 +29,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Twist,6>("KDL.Twist") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Twist > >("KDL.Twist[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Twist > >("KDL.cTwist[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitVector.cpp
+++ b/kdl_typekit/src/kdlTypekitVector.cpp
@@ -29,5 +29,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Vector,3>("KDL.Vector") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Vector > >("KDL.Vector[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Vector > >("KDL.cVector[]") );
-  };
+  }
 }  

--- a/kdl_typekit/src/kdlTypekitWrench.cpp
+++ b/kdl_typekit/src/kdlTypekitWrench.cpp
@@ -29,5 +29,5 @@ namespace KDL{
     RTT::types::Types()->addType( new KDLVectorTypeInfo<Wrench,6>("KDL.Wrench") );
     RTT::types::Types()->addType( new SequenceTypeInfo<std::vector< Wrench > >("KDL.Wrench[]") );
     RTT::types::Types()->addType( new CArrayTypeInfo<RTT::types::carray< Wrench > >("KDL.cWrench[]") );
-  };
+  }
 }  


### PR DESCRIPTION
Fixes lots of errors like
```cpp
/opt/orocos/kinetic/src/rtt_geometry/kdl_typekit/src/kdlTypekit.hpp:91:4: warning: extra ‘;’ [-Wpedantic]
   };                                                                                                                                                                                                                                  
    ^
```
if the packages are compiled with the `-pedantic` options and without C++11.