### PR TITLE
Add fixed size vectors

### DIFF
--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -336,43 +336,42 @@ namespace Eigen{
 
     template<class VectorType>
     struct vector_size_value_constructor
-        : public std::binary_function<int,double,const VectorType&>
+        : public std::binary_function<int,double,VectorType>
     {
-        typedef const VectorType& (Signature)( int, double );
+        typedef VectorType (Signature)( int, double );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_size_value_constructor() :
             ptr( new VectorType ){}
-        const VectorType& operator()(int size,double value ) const
+        VectorType operator()(int size,double value ) const
         {
-            *ptr=VectorType::Constant(size,value);
-            return *ptr;
+            return VectorType::Constant(size,value);
         }
     };
 
     template<class VectorType>
     struct vector_fixed_value_constructor
-        : public std::unary_function<double,const VectorType&>
+        : public std::unary_function<double,VectorType>
     {
-        typedef const VectorType& (Signature)( double );
+        typedef VectorType (Signature)( double );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_fixed_value_constructor() :
             ptr( new VectorType ){}
-        const VectorType& operator()(double value) const
+        VectorType operator()(double value) const
         {
             ptr->setConstant(value);
-            return *(ptr);
+            return *ptr;
         }
     };
 
     template<class VectorType>
     struct vector_array_constructor
-        : public std::unary_function<std::vector<double>,const VectorType&>
+        : public std::unary_function<std::vector<double>,VectorType>
     {
         typedef const VectorType& (Signature)( std::vector<double> );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_array_constructor() :
             ptr( new VectorType ){}
-        const VectorType& operator()(std::vector<double> values) const
+        VectorType operator()(std::vector<double> values) const
         {
             // Explicitely resize rather than use aliasing implicitely
             if(ptr->size() != values.size() && VectorType::RowsAtCompileTime == Eigen::Dynamic)
@@ -380,46 +379,42 @@ namespace Eigen{
                 ptr->resize(values.size());
             }
 
-            *ptr = VectorType::Map(values.data(),values.size());
-            return *ptr;
+            return VectorType::Map(values.data(),values.size());
         }
     };
 
     template<class VectorType>
     struct vector_fixed_array_constructor
-        : public std::unary_function<std::vector<double>,const VectorType&>
+        : public std::unary_function<std::vector<double>,VectorType>
     {
-        typedef const VectorType& (Signature)( std::vector<double> );
+        typedef VectorType (Signature)( std::vector<double> );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_fixed_array_constructor() :
             ptr( new VectorType ){}
-        const VectorType& operator()(std::vector<double> values) const
+        VectorType operator()(std::vector<double> values) const
         {
             if(ptr->size() != values.size())
             {
                 log(Debug) << "Cannot copy an std vector of size " << values.size()
-                           << " into a fixed size vector of size " << ptr->size()
+                           << " into an eigen vector of (fixed) size " << ptr->size()
                            << endlog();
-                *ptr = VectorType::Constant(values.size(), RTT::internal::NA<double&>::na());
-                return *ptr;
+                return VectorType::Constant(values.size(), RTT::internal::NA<double&>::na());
             }
-            *ptr = VectorType::Map(values.data(),ptr->size());
-            return *ptr;
+            return VectorType::Map(values.data(),ptr->size());
         }
     };
 
     template<class VectorType>
     struct vector_size_constructor
-        : public std::unary_function<int,const VectorType&>
+        : public std::unary_function<int,VectorType>
     {
-        typedef const VectorType& (Signature)( int );
+        typedef VectorType (Signature)( int );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_size_constructor() :
             ptr( new VectorType() ){}
-        const VectorType& operator()(int size ) const
+        VectorType operator()(int size ) const
         {
-            *ptr = VectorType::Zero(size);
-            return *ptr;
+            return VectorType::Zero(size);
         }
     };
 
@@ -436,16 +431,15 @@ namespace Eigen{
 
     template<typename MatrixType>
     struct matrix_i_j_constructor
-        : public std::binary_function<int,int,const MatrixType&>
+        : public std::binary_function<int,int,MatrixType>
     {
-        typedef const MatrixType& (Signature)( int, int );
+        typedef MatrixType (Signature)( int, int );
         mutable boost::shared_ptr< MatrixType > ptr;
         matrix_i_j_constructor() :
             ptr( new MatrixType() ){}
-        const MatrixType& operator()(int size1,int size2) const
+        MatrixType operator()(int size1,int size2) const
         {
-            *ptr = MatrixType::Zero(size1,size2);
-            return *ptr;
+            return MatrixType::Zero(size1,size2);
         }
     };
 

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -367,12 +367,12 @@ namespace Eigen{
     };
 
     template<class VectorType>
-    struct vector_index_constructor
+    struct vector_size_constructor
         : public std::unary_function<int,const VectorType&>
     {
         typedef const VectorType& (Signature)( int );
         mutable boost::shared_ptr< VectorType > ptr;
-        vector_index_constructor() :
+        vector_size_constructor() :
             ptr( new VectorType() ){}
         const VectorType& operator()(int size ) const
         {
@@ -430,11 +430,7 @@ namespace Eigen{
 
     bool EigenTypekitPlugin::loadConstructors()
     {
-        RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_index_constructor<VectorXd>()));
-        RTT::types::Types()->type("eigen_vector2")->addConstructor(types::newConstructor(vector_index_constructor<Vector2d>()));
-        RTT::types::Types()->type("eigen_vector3")->addConstructor(types::newConstructor(vector_index_constructor<Vector3d>()));
-        RTT::types::Types()->type("eigen_vector4")->addConstructor(types::newConstructor(vector_index_constructor<Vector4d>()));
-        RTT::types::Types()->type("eigen_vector6")->addConstructor(types::newConstructor(vector_index_constructor<Vector6d>()));
+        RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_size_constructor<VectorXd>()));
         RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_index_value_constructor<VectorXd>()));
         RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_index_array_constructor<VectorXd>()));
         RTT::types::Types()->type("eigen_vector2")->addConstructor(types::newConstructor(vector_index_value_constructor<Vector2d>()));

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -345,8 +345,8 @@ namespace Eigen{
         const VectorType& operator()(int size,double value ) const
         {
             ptr->conservativeResizeLike(VectorType::Zero(size));
-            (*ptr)=VectorType::Constant(size,value);
-            return *(ptr);
+            *ptr=VectorType::Constant(size,value);
+            return *ptr;
         }
     };
 
@@ -375,14 +375,14 @@ namespace Eigen{
             ptr( new VectorType ){}
         const VectorType& operator()(std::vector<double> values) const
         {
-            // Explicitely resize rather than use aliasing
+            // Explicitely resize rather than use aliasing implicitely
             if(ptr->size() != values.size() && VectorType::RowsAtCompileTime == Eigen::Dynamic)
             {
-                ptr->conservativeResize(values.size());
+                ptr->resize(values.size());
             }
 
-            (*ptr)=VectorType::Map(&values[0],values.size());
-            return *(ptr);
+            *ptr = VectorType::Map(values.data(),values.size());
+            return *ptr;
         }
     };
 
@@ -398,13 +398,14 @@ namespace Eigen{
         {
             if(ptr->size() != values.size())
             {
-                log(Error) << "Cannot copy an std vector of size " << values.size()
+                log(Debug) << "Cannot copy an std vector of size " << values.size()
                            << " into a fixed size vector of size " << ptr->size()
                            << endlog();
-                return *(ptr);
+                *ptr = VectorType::Constant(values.size(), RTT::internal::NA<double&>::na());
+                return *ptr;
             }
-            (*ptr)=VectorType::Map(&values[0],ptr->size());
-            return *(ptr);
+            *ptr = VectorType::Map(values.data(),ptr->size());
+            return *ptr;
         }
     };
 
@@ -418,8 +419,8 @@ namespace Eigen{
             ptr( new VectorType() ){}
         const VectorType& operator()(int size ) const
         {
-            ptr->conservativeResizeLike(VectorType::Zero(size));
-            return *(ptr);
+            *ptr = VectorType::Zero(size);
+            return *ptr;
         }
     };
 
@@ -444,9 +445,8 @@ namespace Eigen{
             ptr( new MatrixType() ){}
         const MatrixType& operator()(int size1,int size2) const
         {
-            ptr->resize(size1,size2);
-            ptr->setZero();
-            return *(ptr);
+            *ptr = MatrixType::Zero(size1,size2);
+            return *ptr;
         }
     };
 

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -344,7 +344,6 @@ namespace Eigen{
             ptr( new VectorType ){}
         const VectorType& operator()(int size,double value ) const
         {
-            ptr->conservativeResizeLike(VectorType::Zero(size));
             *ptr=VectorType::Constant(size,value);
             return *ptr;
         }

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -34,7 +34,7 @@
 #include <rtt/internal/DataSourceGenerator.hpp>
 #include <boost/lexical_cast.hpp>
 
-#define DECLARE_RTT_VECTOR_EXPORTS( VectorType) \
+#define DECLARE_RTT_VECTOR_EXPORTS( VectorType ) \
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< VectorType >; \
 template class RTT_EXPORT RTT::internal::DataSource< VectorType >; \
 template class RTT_EXPORT RTT::internal::AssignableDataSource< VectorType >; \
@@ -52,20 +52,27 @@ DECLARE_RTT_VECTOR_EXPORTS( Eigen::VectorXd )
 DECLARE_RTT_VECTOR_EXPORTS( Eigen::Vector2d )
 DECLARE_RTT_VECTOR_EXPORTS( Eigen::Vector3d )
 DECLARE_RTT_VECTOR_EXPORTS( Eigen::Vector4d )
+DECLARE_RTT_VECTOR_EXPORTS( Eigen::Vector6d )
 
-template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::DataSource< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::AssignableDataSource< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::AssignCommand< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::ValueDataSource< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::ConstantDataSource< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::internal::ReferenceDataSource< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::OutputPort< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::InputPort< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::Property< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::Attribute< Eigen::MatrixXd >;
-template class RTT_EXPORT RTT::Constant< Eigen::MatrixXd >;
+#define DECLARE_RTT_MATRIX_EXPORTS( MatrixType ) \
+template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< MatrixType >; \
+template class RTT_EXPORT RTT::internal::DataSource< MatrixType >; \
+template class RTT_EXPORT RTT::internal::AssignableDataSource< MatrixType >; \
+template class RTT_EXPORT RTT::internal::AssignCommand< MatrixType >; \
+template class RTT_EXPORT RTT::internal::ValueDataSource< MatrixType >; \
+template class RTT_EXPORT RTT::internal::ConstantDataSource< MatrixType >; \
+template class RTT_EXPORT RTT::internal::ReferenceDataSource< MatrixType >; \
+template class RTT_EXPORT RTT::OutputPort< MatrixType >; \
+template class RTT_EXPORT RTT::InputPort< MatrixType >; \
+template class RTT_EXPORT RTT::Property< MatrixType >; \
+template class RTT_EXPORT RTT::Attribute< MatrixType >; \
+template class RTT_EXPORT RTT::Constant< MatrixType >;
 
+DECLARE_RTT_MATRIX_EXPORTS( Eigen::MatrixXd )
+DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix2d )
+DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix3d )
+DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix4d )
+DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix6d )
 
 #include <Eigen/Core>
 namespace Eigen{
@@ -74,36 +81,32 @@ namespace Eigen{
     using namespace RTT::detail;
     using namespace RTT::types;
 
-    std::istream& operator>>(std::istream &is,MatrixXd& v){
+    template<typename Derived>
+    std::istream& operator>>(std::istream &is, EigenBase<Derived>& v){
       return is;
     }
-
-#define DECLARE_VECTOR_GET_FUNCTIONS(VectorType) \
-    std::istream& operator>>(std::istream &is,VectorType& v){ \
-      return is; \
-    } \
-    double& get_item(VectorType& v, int index) \
-    { \
-        if (index >= (int) (v.size()) || index < 0) \
-            return RTT::internal::NA<double&>::na(); \
-        return v[index]; \
-    } \
-    double get_item_copy(const VectorType& v, int index) \
-    { \
-        if (index >= (int) (v.size()) || index < 0) \
-            return RTT::internal::NA<double>::na(); \
-        return v[index]; \
-    } \
-    int get_size(const VectorType& v) \
-    { \
-        return v.size(); \
+    
+    template<typename VectorType>
+    double& get_item(VectorType& v, int index)
+    {
+        if (index >= (int) (v.size()) || index < 0)
+            return RTT::internal::NA<double&>::na();
+        return v[index];
     }
     
-    DECLARE_VECTOR_GET_FUNCTIONS( Eigen::VectorXd )
-    DECLARE_VECTOR_GET_FUNCTIONS( Eigen::Vector2d )
-    DECLARE_VECTOR_GET_FUNCTIONS( Eigen::Vector3d )
-    DECLARE_VECTOR_GET_FUNCTIONS( Eigen::Vector4d )
+    template<typename VectorType>
+    double get_item_copy(const VectorType& v, int index)
+    {
+        if (index >= (int) (v.size()) || index < 0)
+            return RTT::internal::NA<double>::na();
+        return v[index];
+    }
     
+    template<typename VectorType>
+    int get_size(const VectorType& v)
+    {
+        return v.size();
+    }
 
     template<class VectorType>
     struct VectorTypeInfo : public types::TemplateTypeInfo<VectorType,true>
@@ -111,12 +114,10 @@ namespace Eigen{
                           , public MemberFactory
 #endif
     {
-        VectorTypeInfo(const std::string& type_name):TemplateTypeInfo<VectorType, true >(type_name), type_name_(type_name)
+        VectorTypeInfo(const std::string& type_name):TemplateTypeInfo<VectorType, true >(type_name)
         {
         };
-        
-        const std::string type_name_; 
-        
+                
 #if (RTT_VERSION_MAJOR*100+RTT_VERSION_MINOR) >= 206
         bool installTypeInfoObject(TypeInfo* ti) {
             // aquire a shared reference to the this object
@@ -136,8 +137,8 @@ namespace Eigen{
         bool resize(base::DataSourceBase::shared_ptr arg, int size) const
         {
             if (arg->isAssignable()) {
-	        typedef typename RTT::internal::AssignableDataSource<VectorType>::shared_ptr sh_ptr;
-            sh_ptr asarg = RTT::internal::AssignableDataSource<VectorType>::narrow( arg.get() );
+	        typedef typename RTT::internal::AssignableDataSource<VectorType >::shared_ptr sh_ptr;
+            sh_ptr asarg = RTT::internal::AssignableDataSource<VectorType >::narrow( arg.get() );
                 asarg->set().resize( size );
                 asarg->updated();
                 return true;
@@ -172,8 +173,7 @@ namespace Eigen{
             if ( id_name ) {
                 if ( id_name->get() == "size" || id_name->get() == "capacity") {
                     try {
-                        int (*get_size_pf)(const VectorType&) = get_size;
-                        return RTT::internal::newFunctorDataSource(get_size_pf, RTT::internal::GenerateDataSource()(item.get()) );
+                        return RTT::internal::newFunctorDataSource(&get_size<VectorType>, RTT::internal::GenerateDataSource()(item.get()) );
                     } catch(...) {}
                 }
             }
@@ -182,13 +182,11 @@ namespace Eigen{
                 try {
                     if ( item->isAssignable() )
                     {
-                        double& (*get_item_pf)(VectorType&,int) = get_item;
-                        return RTT::internal::newFunctorDataSource(get_item_pf, RTT::internal::GenerateDataSource()(item.get(), id_indx.get() ) );
+                        return RTT::internal::newFunctorDataSource(get_item<VectorType>, RTT::internal::GenerateDataSource()(item.get(), id_indx.get() ) );
                     }
                     else
                     {
-                        double (*get_item_copy_pf)(const VectorType&,int) = get_item_copy;
-                        return RTT::internal::newFunctorDataSource(get_item_copy_pf, RTT::internal::GenerateDataSource()(item.get(), id_indx.get() ) );
+                        return RTT::internal::newFunctorDataSource(get_item_copy<VectorType>, RTT::internal::GenerateDataSource()(item.get(), id_indx.get() ) );
                     }
                 } catch(...) {}
             }
@@ -206,7 +204,7 @@ namespace Eigen{
 
         virtual bool decomposeTypeImpl(const VectorType& vec, PropertyBag& targetbag) const
         {
-            targetbag.setType(type_name_);
+            targetbag.setType(this->getTypeName());
             int dimension = vec.rows();
             std::string str;
 
@@ -225,7 +223,7 @@ namespace Eigen{
 
       virtual bool composeTypeImpl(const PropertyBag& bag, VectorType& result) const{
 
-            if ( bag.getType() == type_name_ ) {
+            if ( bag.getType() == this->getTypeName() ) {
                 int dimension = bag.size();
                 result.resize( dimension );
 
@@ -242,7 +240,7 @@ namespace Eigen{
                     }
                 }
             }else{
-                log(Error) << "Composing Property< VectorType > :"
+                log(Error) << "Composing Property< " << this->getTypeName() << " > :"
                            << " type mismatch, got type '"<< bag.getType()
                            << "', expected type "<<"eigen_vector."<<endlog();
                 return false;
@@ -251,13 +249,14 @@ namespace Eigen{
         };
     };
 
-    struct MatrixTypeInfo : public types::TemplateTypeInfo<MatrixXd,true>{
-        MatrixTypeInfo():TemplateTypeInfo<MatrixXd, true >("eigen_matrix"){
+    template<typename MatrixType>
+    struct MatrixTypeInfo : public types::TemplateTypeInfo<MatrixType,true>{
+        MatrixTypeInfo(const std::string& type_name):TemplateTypeInfo<MatrixType, true >(type_name){
         };
 
 
-        bool decomposeTypeImpl(const MatrixXd& mat, PropertyBag& targetbag) const{
-            targetbag.setType("eigen_matrix");
+        bool decomposeTypeImpl(const MatrixType& mat, PropertyBag& targetbag) const{
+            targetbag.setType(this->getTypeName());
             unsigned int dimension = mat.rows();
             if(!targetbag.empty())
                 return false;
@@ -271,8 +270,8 @@ namespace Eigen{
             return true;
         };
 
-        bool composeTypeImpl(const PropertyBag& bag, MatrixXd& result) const{
-            if ( bag.getType() == "eigen_matrix" ) {
+        bool composeTypeImpl(const PropertyBag& bag, MatrixType& result) const{
+            if ( bag.getType() == this->getTypeName() ) {
                 unsigned int rows = bag.size();
                 unsigned int cols = 0;
                 // Get values
@@ -305,7 +304,7 @@ namespace Eigen{
                     }
                 }
             }else {
-                log(Error) << "Composing Property< MatrixXd > :"
+                log(Error) << "Composing Property< " << this->getTypeName() << " > :"
                            << " type mismatch, got type '"<< bag.getType()
                            << "', expected type "<<"ublas_matrix."<<endlog();
                 return false;
@@ -325,11 +324,12 @@ namespace Eigen{
             return v(index);
         }
     };
-
-    struct get_size
-        : public std::unary_function<const VectorXd&, int>
+    
+    template<class VectorType>
+    struct get_size_functor
+        : public std::unary_function<const VectorType&, int>
     {
-        int operator()(const VectorXd& cont ) const
+        int operator()(const VectorType& cont ) const
         {
             return cont.rows();
         }
@@ -381,24 +381,26 @@ namespace Eigen{
         }
     };
 
-    struct matrix_index
-        : public std::ternary_function<const MatrixXd&, int, int, double>
+    template<typename MatrixType>
+    struct matrix_index_functor
+        : public std::ternary_function<const MatrixType&, int, int, double>
     {
-        double operator()(const MatrixXd& m, int i, int j) const{
+        double operator()(const MatrixType& m, int i, int j) const{
             if ( i >= (int)(m.rows()) || i < 0 || j<0 || j>= (int)(m.cols()))
                 return 0.0;
             return m(i,j);
         }
     };
 
+    template<typename MatrixType>
     struct matrix_i_j_constructor
-        : public std::binary_function<int,int,const MatrixXd&>
+        : public std::binary_function<int,int,const MatrixType&>
     {
-        typedef const MatrixXd& (Signature)( int, int );
-        mutable boost::shared_ptr< MatrixXd > ptr;
+        typedef const MatrixType& (Signature)( int, int );
+        mutable boost::shared_ptr< MatrixType > ptr;
         matrix_i_j_constructor() :
-            ptr( new MatrixXd() ){}
-        const MatrixXd& operator()(int size1,int size2) const
+            ptr( new MatrixType() ){}
+        const MatrixType& operator()(int size1,int size2) const
         {
             ptr->resize(size1,size2);
             return *(ptr);
@@ -417,7 +419,12 @@ namespace Eigen{
         RTT::types::TypeInfoRepository::Instance()->addType( new VectorTypeInfo<Vector2d>("eigen_vector2") );
         RTT::types::TypeInfoRepository::Instance()->addType( new VectorTypeInfo<Vector3d>("eigen_vector3") );
         RTT::types::TypeInfoRepository::Instance()->addType( new VectorTypeInfo<Vector4d>("eigen_vector4") );
-        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo() );
+        RTT::types::TypeInfoRepository::Instance()->addType( new VectorTypeInfo<Vector6d>("eigen_vector6") );
+        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<MatrixXd>("eigen_matrix") );
+        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix2d>("eigen_matrix2") );
+        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix3d>("eigen_matrix3") );
+        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix4d>("eigen_matrix4") );
+        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix6d>("eigen_matrix6") );
         return true;
     }
 
@@ -427,6 +434,7 @@ namespace Eigen{
         RTT::types::Types()->type("eigen_vector2")->addConstructor(types::newConstructor(vector_index_constructor<Vector2d>()));
         RTT::types::Types()->type("eigen_vector3")->addConstructor(types::newConstructor(vector_index_constructor<Vector3d>()));
         RTT::types::Types()->type("eigen_vector4")->addConstructor(types::newConstructor(vector_index_constructor<Vector4d>()));
+        RTT::types::Types()->type("eigen_vector6")->addConstructor(types::newConstructor(vector_index_constructor<Vector6d>()));
         RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_index_value_constructor<VectorXd>()));
         RTT::types::Types()->type("eigen_vector")->addConstructor(types::newConstructor(vector_index_array_constructor<VectorXd>()));
         RTT::types::Types()->type("eigen_vector2")->addConstructor(types::newConstructor(vector_index_value_constructor<Vector2d>()));
@@ -435,7 +443,13 @@ namespace Eigen{
         RTT::types::Types()->type("eigen_vector3")->addConstructor(types::newConstructor(vector_index_array_constructor<Vector3d>()));
         RTT::types::Types()->type("eigen_vector4")->addConstructor(types::newConstructor(vector_index_value_constructor<Vector4d>()));
         RTT::types::Types()->type("eigen_vector4")->addConstructor(types::newConstructor(vector_index_array_constructor<Vector4d>()));
-        RTT::types::Types()->type("eigen_matrix")->addConstructor(types::newConstructor(matrix_i_j_constructor()));
+        RTT::types::Types()->type("eigen_vector6")->addConstructor(types::newConstructor(vector_index_value_constructor<Vector6d>()));
+        RTT::types::Types()->type("eigen_vector6")->addConstructor(types::newConstructor(vector_index_array_constructor<Vector6d>()));
+        RTT::types::Types()->type("eigen_matrix")->addConstructor(types::newConstructor(matrix_i_j_constructor<MatrixXd>()));
+        RTT::types::Types()->type("eigen_matrix2")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix2d>()));
+        RTT::types::Types()->type("eigen_matrix3")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix3d>()));
+        RTT::types::Types()->type("eigen_matrix4")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix4d>()));
+        RTT::types::Types()->type("eigen_matrix6")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix6d>()));
         return true;
     }
 
@@ -445,6 +459,7 @@ namespace Eigen{
         RTT::types::OperatorRepository::Instance()->add( newBinaryOperator( "[]", vector_index<Vector2d>() ) );
         RTT::types::OperatorRepository::Instance()->add( newBinaryOperator( "[]", vector_index<Vector3d>() ) );
         RTT::types::OperatorRepository::Instance()->add( newBinaryOperator( "[]", vector_index<Vector4d>() ) );
+        RTT::types::OperatorRepository::Instance()->add( newBinaryOperator( "[]", vector_index<Vector6d>() ) );
         //RTT::types::OperatorRepository::Instance()->add( newDotOperator( "size", get_size() ) );
         //RTT::types::OperatorRepository::Instance()->add( newTernaryOperator( "[,]", matrix_index() ) );
         return true;

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -367,19 +367,14 @@ namespace Eigen{
     struct vector_array_constructor
         : public std::unary_function<std::vector<double>,VectorType>
     {
-        typedef const VectorType& (Signature)( std::vector<double> );
+        typedef VectorType (Signature)( std::vector<double> );
         mutable boost::shared_ptr< VectorType > ptr;
         vector_array_constructor() :
             ptr( new VectorType ){}
         VectorType operator()(std::vector<double> values) const
         {
-            // Explicitely resize rather than use aliasing implicitely
-            if(ptr->size() != values.size() && VectorType::RowsAtCompileTime == Eigen::Dynamic)
-            {
-                ptr->resize(values.size());
-            }
-
-            return VectorType::Map(values.data(),values.size());
+            *ptr = VectorType::Map(values.data(),values.size());
+            return *ptr;
         }
     };
 

--- a/eigen_typekit/eigen_typekit.cpp
+++ b/eigen_typekit/eigen_typekit.cpp
@@ -72,7 +72,6 @@ DECLARE_RTT_MATRIX_EXPORTS( Eigen::MatrixXd )
 DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix2d )
 DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix3d )
 DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix4d )
-DECLARE_RTT_MATRIX_EXPORTS( Eigen::Matrix6d )
 
 #include <Eigen/Core>
 namespace Eigen{
@@ -424,7 +423,6 @@ namespace Eigen{
         RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix2d>("eigen_matrix2") );
         RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix3d>("eigen_matrix3") );
         RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix4d>("eigen_matrix4") );
-        RTT::types::TypeInfoRepository::Instance()->addType( new MatrixTypeInfo<Matrix6d>("eigen_matrix6") );
         return true;
     }
 
@@ -445,7 +443,6 @@ namespace Eigen{
         RTT::types::Types()->type("eigen_matrix2")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix2d>()));
         RTT::types::Types()->type("eigen_matrix3")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix3d>()));
         RTT::types::Types()->type("eigen_matrix4")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix4d>()));
-        RTT::types::Types()->type("eigen_matrix6")->addConstructor(types::newConstructor(matrix_i_j_constructor<Matrix6d>()));
         return true;
     }
 

--- a/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
+++ b/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
@@ -37,54 +37,115 @@ public:
 	virtual bool loadOperators();
 };
 }
-#ifdef CORELIB_DATASOURCE_HPP
-    extern template class RTT::internal::DataSourceTypeInfo< Eigen::VectorXd >;
-    extern template class RTT::internal::DataSource< Eigen::VectorXd >;
-    extern template class RTT::internal::AssignableDataSource< Eigen::VectorXd >;
-    extern template class RTT::internal::AssignCommand< Eigen::VectorXd >;
-#endif
-#ifdef ORO_CORELIB_DATASOURCES_HPP
-    extern template class RTT::internal::ValueDataSource< Eigen::VectorXd >;
-    extern template class RTT::internal::ConstantDataSource< Eigen::VectorXd >;
-    extern template class RTT::internal::ReferenceDataSource< Eigen::VectorXd >;
-#endif
-#ifdef ORO_OUTPUT_PORT_HPP
-    extern template class RTT::OutputPort< Eigen::VectorXd >;
-#endif
-#ifdef ORO_INPUT_PORT_HPP
-    extern template class RTT::InputPort< Eigen::VectorXd >;
-#endif
-#ifdef ORO_PROPERTY_HPP
-    extern template class RTT::Property< Eigen::VectorXd >;
-#endif
-#ifdef ORO_CORELIB_ATTRIBUTE_HPP
-    extern template class RTT::Attribute< Eigen::VectorXd >;
-    extern template class RTT::Constant< Eigen::VectorXd >;
-#endif
 
 #ifdef CORELIB_DATASOURCE_HPP
-    extern template class RTT::internal::DataSourceTypeInfo< Eigen::MatrixXd >;
-    extern template class RTT::internal::DataSource< Eigen::MatrixXd >;
-    extern template class RTT::internal::AssignableDataSource< Eigen::MatrixXd >;
-    extern template class RTT::internal::AssignCommand< Eigen::MatrixXd >;
+#define DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(VectorType) \
+    extern template class RTT::internal::DataSourceTypeInfo< VectorType >; \
+    extern template class RTT::internal::DataSource< VectorType >; \
+    extern template class RTT::internal::AssignableDataSource< VectorType >; \
+    extern template class RTT::internal::AssignCommand< VectorType >;
+
+    DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::VectorXd)
+    DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector2d)
+    DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector3d)
+    DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector4d)
+#endif
+
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+#define DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(VectorType) \
+    extern template class RTT::internal::ValueDataSource< VectorType >; \
+    extern template class RTT::internal::ConstantDataSource< VectorType >; \
+    extern template class RTT::internal::ReferenceDataSource< VectorType >;
+    
+    DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::VectorXd)
+    DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector2d)
+    DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector3d)
+    DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector4d)
+#endif
+
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< Eigen::VectorXd >;
+    extern template class RTT::OutputPort< Eigen::Vector2d >;
+    extern template class RTT::OutputPort< Eigen::Vector3d >;
+    extern template class RTT::OutputPort< Eigen::Vector4d >;
+#endif
+
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< Eigen::VectorXd >;
+    extern template class RTT::InputPort< Eigen::Vector2d >;
+    extern template class RTT::InputPort< Eigen::Vector3d >;
+    extern template class RTT::InputPort< Eigen::Vector4d >;
+#endif
+
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< Eigen::VectorXd >;
+    extern template class RTT::Property< Eigen::Vector2d >;
+    extern template class RTT::Property< Eigen::Vector3d >;
+    extern template class RTT::Property< Eigen::Vector4d >;
+#endif
+
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+#define DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(VectorType) \
+    extern template class RTT::Attribute< VectorType >; \
+    extern template class RTT::Constant< VectorType >;
+    
+    DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::VectorXd)
+    DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector2d)
+    DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector3d)
+    DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector4d)
+#endif
+
+
+#ifdef CORELIB_DATASOURCE_HPP
+#define DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(MatrixType) \
+    extern template class RTT::internal::DataSourceTypeInfo< MatrixType >; \
+    extern template class RTT::internal::DataSource< MatrixType >; \
+    extern template class RTT::internal::AssignableDataSource< MatrixType >; \
+    extern template class RTT::internal::AssignCommand< MatrixType >;
+    
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::MatrixXd)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
 #endif
 #ifdef ORO_CORELIB_DATASOURCES_HPP
-    extern template class RTT::internal::ValueDataSource< Eigen::MatrixXd >;
-    extern template class RTT::internal::ConstantDataSource< Eigen::MatrixXd >;
-    extern template class RTT::internal::ReferenceDataSource< Eigen::MatrixXd >;
+#define DECLARE_MATRIX_ORO_CORELIB_DATASOURCES_HPP(MatrixType) \
+    extern template class RTT::internal::ValueDataSource< MatrixType >; \
+    extern template class RTT::internal::ConstantDataSource< MatrixType >; \
+    extern template class RTT::internal::ReferenceDataSource< MatrixType >;
+    
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::MatrixXd)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
     extern template class RTT::OutputPort< Eigen::MatrixXd >;
+    extern template class RTT::OutputPort< Eigen::Matrix2d >;
+    extern template class RTT::OutputPort< Eigen::Matrix3d >;
+    extern template class RTT::OutputPort< Eigen::Matrix4d >;
 #endif
 #ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< Eigen::MatrixXd >;
+    extern template class RTT::InputPort< Eigen::Matrix2d >;
+    extern template class RTT::InputPort< Eigen::Matrix3d >;
+    extern template class RTT::InputPort< Eigen::Matrix4d >;
 #endif
 #ifdef ORO_PROPERTY_HPP
     extern template class RTT::Property< Eigen::MatrixXd >;
+    extern template class RTT::Property< Eigen::Matrix2d >;
+    extern template class RTT::Property< Eigen::Matrix3d >;
+    extern template class RTT::Property< Eigen::Matrix4d >;
 #endif
 #ifdef ORO_CORELIB_ATTRIBUTE_HPP
-    extern template class RTT::Attribute< Eigen::MatrixXd >;
-    extern template class RTT::Constant< Eigen::MatrixXd >;
+#define DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(MatrixType) \
+    extern template class RTT::Attribute< MatrixType >; \
+    extern template class RTT::Constant< MatrixType >;
+    
+    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::MatrixXd)
+    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix2d)
+    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix3d)
+    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix4d)
 #endif
 
 #endif // ifndef EIGEN_TYPEKIT_HPP

--- a/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
+++ b/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
@@ -28,6 +28,9 @@
 // import most common Eigen types 
 namespace Eigen {
 
+typedef Matrix<double,6,1> Vector6d;
+typedef Matrix<double,6,6> Matrix6d;
+
 class EigenTypekitPlugin: public RTT::types::TypekitPlugin {
 public:
 	virtual std::string getName();
@@ -49,6 +52,7 @@ public:
     DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector2d)
     DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector3d)
     DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector4d)
+    DECLARE_VECTOR_CORELIB_DATASOURCE_HPP(Eigen::Vector6d)
 #endif
 
 #ifdef ORO_CORELIB_DATASOURCES_HPP
@@ -61,6 +65,7 @@ public:
     DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector2d)
     DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector3d)
     DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector4d)
+    DECLARE_VECTOR_ORO_CORELIB_DATASOURCES_HPP(Eigen::Vector6d)
 #endif
 
 #ifdef ORO_OUTPUT_PORT_HPP
@@ -68,6 +73,7 @@ public:
     extern template class RTT::OutputPort< Eigen::Vector2d >;
     extern template class RTT::OutputPort< Eigen::Vector3d >;
     extern template class RTT::OutputPort< Eigen::Vector4d >;
+    extern template class RTT::OutputPort< Eigen::Vector6d >;
 #endif
 
 #ifdef ORO_INPUT_PORT_HPP
@@ -75,6 +81,7 @@ public:
     extern template class RTT::InputPort< Eigen::Vector2d >;
     extern template class RTT::InputPort< Eigen::Vector3d >;
     extern template class RTT::InputPort< Eigen::Vector4d >;
+    extern template class RTT::InputPort< Eigen::Vector6d >;
 #endif
 
 #ifdef ORO_PROPERTY_HPP
@@ -82,6 +89,7 @@ public:
     extern template class RTT::Property< Eigen::Vector2d >;
     extern template class RTT::Property< Eigen::Vector3d >;
     extern template class RTT::Property< Eigen::Vector4d >;
+    extern template class RTT::Property< Eigen::Vector6d >;
 #endif
 
 #ifdef ORO_CORELIB_ATTRIBUTE_HPP
@@ -93,6 +101,7 @@ public:
     DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector2d)
     DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector3d)
     DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector4d)
+    DECLARE_VECTOR_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Vector6d)
 #endif
 
 
@@ -107,6 +116,7 @@ public:
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix6d)
 #endif
 #ifdef ORO_CORELIB_DATASOURCES_HPP
 #define DECLARE_MATRIX_ORO_CORELIB_DATASOURCES_HPP(MatrixType) \
@@ -118,24 +128,28 @@ public:
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
+    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix6d)
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
     extern template class RTT::OutputPort< Eigen::MatrixXd >;
     extern template class RTT::OutputPort< Eigen::Matrix2d >;
     extern template class RTT::OutputPort< Eigen::Matrix3d >;
     extern template class RTT::OutputPort< Eigen::Matrix4d >;
+    extern template class RTT::OutputPort< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< Eigen::MatrixXd >;
     extern template class RTT::InputPort< Eigen::Matrix2d >;
     extern template class RTT::InputPort< Eigen::Matrix3d >;
     extern template class RTT::InputPort< Eigen::Matrix4d >;
+    extern template class RTT::InputPort< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_PROPERTY_HPP
     extern template class RTT::Property< Eigen::MatrixXd >;
     extern template class RTT::Property< Eigen::Matrix2d >;
     extern template class RTT::Property< Eigen::Matrix3d >;
     extern template class RTT::Property< Eigen::Matrix4d >;
+    extern template class RTT::Property< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_CORELIB_ATTRIBUTE_HPP
 #define DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(MatrixType) \
@@ -146,6 +160,7 @@ public:
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix4d)
+    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix6d)
 #endif
 
 #endif // ifndef EIGEN_TYPEKIT_HPP

--- a/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
+++ b/eigen_typekit/include/orocos/eigen_typekit/eigen_typekit.hpp
@@ -29,7 +29,6 @@
 namespace Eigen {
 
 typedef Matrix<double,6,1> Vector6d;
-typedef Matrix<double,6,6> Matrix6d;
 
 class EigenTypekitPlugin: public RTT::types::TypekitPlugin {
 public:
@@ -116,7 +115,6 @@ public:
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
-    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix6d)
 #endif
 #ifdef ORO_CORELIB_DATASOURCES_HPP
 #define DECLARE_MATRIX_ORO_CORELIB_DATASOURCES_HPP(MatrixType) \
@@ -128,28 +126,24 @@ public:
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix4d)
-    DECLARE_MATRIX_CORELIB_DATASOURCE_HPP(Eigen::Matrix6d)
 #endif
 #ifdef ORO_OUTPUT_PORT_HPP
     extern template class RTT::OutputPort< Eigen::MatrixXd >;
     extern template class RTT::OutputPort< Eigen::Matrix2d >;
     extern template class RTT::OutputPort< Eigen::Matrix3d >;
     extern template class RTT::OutputPort< Eigen::Matrix4d >;
-    extern template class RTT::OutputPort< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_INPUT_PORT_HPP
     extern template class RTT::InputPort< Eigen::MatrixXd >;
     extern template class RTT::InputPort< Eigen::Matrix2d >;
     extern template class RTT::InputPort< Eigen::Matrix3d >;
     extern template class RTT::InputPort< Eigen::Matrix4d >;
-    extern template class RTT::InputPort< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_PROPERTY_HPP
     extern template class RTT::Property< Eigen::MatrixXd >;
     extern template class RTT::Property< Eigen::Matrix2d >;
     extern template class RTT::Property< Eigen::Matrix3d >;
     extern template class RTT::Property< Eigen::Matrix4d >;
-    extern template class RTT::Property< Eigen::Matrix6d >;
 #endif
 #ifdef ORO_CORELIB_ATTRIBUTE_HPP
 #define DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(MatrixType) \
@@ -160,7 +154,6 @@ public:
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix2d)
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix3d)
     DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix4d)
-    DECLARE_MATRIX_ORO_CORELIB_ATTRIBUTE_HPP(Eigen::Matrix6d)
 #endif
 
 #endif // ifndef EIGEN_TYPEKIT_HPP


### PR DESCRIPTION
This PR adds `eigen_vector2`,`eigen_vector3` and `eigen_vector4` so we can use them in scripting.
Implementation is a bit ugly, but I'd like also to do the same for matrix2d,3d,4d, the default in eigen.

To test it : 
```c 
import("eigen_typekit")

var eigen_vector2 a
var eigen_vector2 b = array(1.,2.)

var eigen_vector3 c
var eigen_vector3 d = array(1.,2.,3.)

var eigen_vector4 e
var eigen_vector4 f = array(1.,2.,3.,4.)
```
Gives : 

```
Deployer [S]> import("eigen_typekit")
 = true                

Deployer [S]> 
Deployer [S]> var eigen_vector2 a
 =                     0                   
0                   

Deployer [S]> var eigen_vector2 b = array(1.,2.)
0.905 [ Warning][Logger] Conversion from array to eigen_vector2
 =                     1                   
2                   

Deployer [S]> 
Deployer [S]> var eigen_vector3 c
 =                     0                   
0                   
3.84581e-315        

Deployer [S]> var eigen_vector3 d = array(1.,2.,3.)
0.910 [ Warning][Logger] Conversion from array to eigen_vector3
 =                     1                   
2                   
3                   

Deployer [S]> 
Deployer [S]> var eigen_vector4 e
 =                     9.75025e+199        
5.55604e+180        
1.27735e-152        
3.68066e+180        

Deployer [S]> var eigen_vector4 f = array(1.,2.,3.,4.)
2.325 [ Warning][Logger] Conversion from array to eigen_vector4
 =                     1                   
2                   
3                   
4     
```