### PR TITLE
Fix Travis on indigo-devel and jade-devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
-language:
-  - cpp
-  - python
-  - ruby
-  - lua
-python:
-  - "2.7"
+sudo: required
+dist: trusty
+language: generic
 compiler:
   - gcc
+
 before_install:
   # Define some config vars
-  - export ROS_DISTRO=hydro
+  - export ROS_DISTRO=indigo
   - export CI_SOURCE_PATH=$(pwd)
   - export EXTRA_CMAKE_ARGS="-DENABLE_CORBA=ON -DCORBA_IMPLEMENTATION=OMNIORB"
   # Bootstrap a minimal ROS installation
-  - git clone https://github.com/jhu-lcsr/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH
+  - git clone https://github.com/orocos/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH
   - ros_ci_bootstrap
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Create isolated workspace based on the ros distro
@@ -23,12 +20,14 @@ before_install:
   - git clone https://github.com/orocos/orocos_kinematics_dynamics.git
   - popd
   # Create non-isolated workspace
-  - mkdir -p ~/ws/src
-  - pushd ~/ws/src
-  - popd
+  - mkdir -p ~/ws
+  - ln -s ../ws_isolated/src ~/ws/src
+  # Install dependencies
   - rosdep install -r --from-paths ~/ws/src ~/ws_isolated/src --ignore-src --rosdistro $ROS_DISTRO -y > /dev/null
-  
-install:
+  # Source the ROS setup script again due to eventually updated env-hooks
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+
+script:
   # Build in an isolated catkin workspace
   - pushd ~/ws_isolated
   - catkin_make_isolated --install -j2 --cmake-args $EXTRA_CMAKE_ARGS
@@ -37,8 +36,6 @@ install:
   # build the normal catkin workspace
   - pushd ~/ws
   - catkin_make -j2
-
-script:
   # Run tests
   - source devel/setup.bash
   - catkin_make run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,11 @@ before_install:
   - git clone https://github.com/orocos/orocos_kinematics_dynamics.git
   - popd
   # Create non-isolated workspace
-  - mkdir -p ~/ws
-  - ln -s ../ws_isolated/src ~/ws/src
+  - mkdir -p ~/ws/src
+  - pushd ~/ws/src
+  - ln -s $CI_SOURCE_PATH
+  - #git clone https://github.com/orocos/orocos_kinematics_dynamics.git
+  - popd
   # Install dependencies
   - rosdep install -r --from-paths ~/ws/src ~/ws_isolated/src --ignore-src --rosdistro $ROS_DISTRO -y > /dev/null
   # Source the ROS setup script again due to eventually updated env-hooks


### PR DESCRIPTION
Cherry-pick of a67a307ceb0cc76b8f1ea9be8003d03af198d1b5 and d22f29002f3a95712f66e7f3758c2a34cb7ab1bb from https://github.com/orocos/rtt_geometry/pull/21. ROS hydro is not supported anymore and recent Travis builds fail because of missing dependencies:

- https://travis-ci.org/orocos/rtt_geometry/builds/327356733
- https://travis-ci.org/orocos/rtt_geometry/builds/376023878

To be merged into indigo-devel and jade-devel.