### PR TITLE
Use ROS industrial_ci for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,43 @@
-sudo: required
-dist: trusty
-language: generic
-compiler:
-  - gcc
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-before_install:
-  # Define some config vars
-  - export ROS_DISTRO=indigo
-  - export CI_SOURCE_PATH=$(pwd)
-  - export EXTRA_CMAKE_ARGS="-DENABLE_CORBA=ON -DCORBA_IMPLEMENTATION=OMNIORB"
-  # Bootstrap a minimal ROS installation
-  - git clone https://github.com/orocos/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH
-  - ros_ci_bootstrap
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Create isolated workspace based on the ros distro
-  - mkdir -p ~/ws_isolated/src
-  - pushd ~/ws_isolated/src
-  - ln -s $CI_SOURCE_PATH
-  - git clone https://github.com/orocos/orocos_kinematics_dynamics.git
-  - popd
-  # Create non-isolated workspace
-  - mkdir -p ~/ws/src
-  - pushd ~/ws/src
-  - ln -s $CI_SOURCE_PATH
-  - #git clone https://github.com/orocos/orocos_kinematics_dynamics.git
-  - popd
-  # Install dependencies
-  - rosdep install -r --from-paths ~/ws/src ~/ws_isolated/src --ignore-src --rosdistro $ROS_DISTRO -y > /dev/null
-  # Source the ROS setup script again due to eventually updated env-hooks
-  - source /opt/ros/$ROS_DISTRO/setup.bash
+language: generic # optional, just removes the language badge
 
+services:
+  - docker
+
+# include the following block if the C/C++ build artifacts should get cached by Travis,
+# CCACHE_DIR needs to get set as well to actually fill the cache
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true # optional, silences the cloning of the target repository
+
+# limit automatic builds to certain branches (and pull requests)
+branches:
+  only:
+  - master
+  - /^toolchain-[\d\.]+[\d]$/
+
+# configure the build environment(s)
+# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
+env:
+  global: # global settings for all jobs
+    - ROS_REPO=ros
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
+  matrix: # each line is a job
+    - ROS_DISTRO="kinetic"
+    #- ROS_DISTRO="melodic"
+
+# allow failures, e.g. for unsupported distros
+#matrix:
+#  allow_failures:
+#    - env: ROS_DISTRO="lunar" ROS_REPO=ros-shadow-fixed
+
+# clone and run industrial_ci
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:
-  # Build in an isolated catkin workspace
-  - pushd ~/ws_isolated
-  - catkin_make_isolated --install -j2 --cmake-args $EXTRA_CMAKE_ARGS
-  - source install_isolated/setup.bash
-  - popd
-  # build the normal catkin workspace
-  - pushd ~/ws
-  - catkin_make -j2
-  # Run tests
-  - source devel/setup.bash
-  - catkin_make run_tests
-  - catkin_make install
+  - .industrial_ci/travis.sh

--- a/kdl_typekit/test/typekit_corba_test.cpp
+++ b/kdl_typekit/test/typekit_corba_test.cpp
@@ -19,8 +19,10 @@ protected:
     {}
 
     virtual void SetUp() {
+        //Start CORBA nameserver (as a fallback if none is running yet)
+        system("omniNames -start -logdir $(mktemp -d) -errlog /dev/null & echo $! > omniNames.pid &");
         //Start server
-        system("./setupcomponent.ops -d");
+        system("./setupcomponent.ops & echo $! > setupcomponent.pid &");
         // Wait for server to startup
         sleep(3);
         //Setup corba
@@ -37,7 +39,8 @@ protected:
         depl.shutdownDeployment();
         RTT::corba::TaskContextServer::ShutdownOrb();
         RTT::corba::TaskContextServer::DestroyOrb();
-        system("pkill -f setupcomponent.ops");
+        system("kill $(cat setupcomponent.pid)");
+        system("kill $(cat omniNames.pid)");
     }
 };
 


### PR DESCRIPTION
Follow-up of #28 for the `toolchain-2.9` branch, as suggested by @ahoarau [here](https://github.com/orocos/rtt_geometry/pull/28#issuecomment-387174851).

The `.travis.yml` config is exactly the same as in https://github.com/orocos/rtt_ros_integration/pull/122.