### PR TITLE
Fix unit tests in kdl_typekit on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ branches:
 # https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:
   global: # global settings for all jobs
-    - ROS_REPO=ros
+    - ROS_REPO=ros-shadow-fixed
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix: # each line is a job
     - ROS_DISTRO="kinetic"


### PR DESCRIPTION
… ~~by setting `WRITABLE_SOURCE=true`.~~ by creating PID files in a temporary folder.

Build error (from https://travis-ci.org/orocos/rtt_geometry/builds/540835882):
```
-- run_tests.py: execute commands with working directory "/root/catkin_ws/src/rtt_geometry/kdl_typekit/test"
  /root/catkin_ws/devel/.private/kdl_typekit/lib/kdl_typekit/typekit_corba_test --gtest_output=xml:/root/catkin_ws/build/kdl_typekit/test_results/kdl_typekit/gtest-typekit_corba_test.xml                                
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from KDLCORBAPluginTest
[ RUN      ] KDLCORBAPluginTest.VectorTest
sh: 1: cannot create omniNames.pid: Read-only file system
sh: 1: cannot create setupcomponent.pid: Read-only file system
3.289 [ ERROR  ][TaskContextProxy] CORBA exception raised when resolving Object !
3.289 [ ERROR  ][TaskContextProxy] NotFound
3.289 [ ERROR  ][loadComponent] TaskContextProxy::Create: CORBA exception raised!
3.289 [ ERROR  ][loadComponent] NotFound
3.289 [ ERROR  ][loadComponent] Failed to load component with name testcomponent: refused to be created.
/root/catkin_ws/src/rtt_geometry/kdl_typekit/test/typekit_corba_test.cpp:32: Failure
Value of: depl.loadComponent("testcomponent","CORBA")
  Actual: false
Expected: true
cat: setupcomponent.pid: No such file or directory
sh: 1: kill: Usage: kill [-s sigspec | -signum | -sigspec] [pid | job]... or
kill -l [exitstatus]
cat: omniNames.pid: No such file or directory
sh: 1: kill: Usage: kill [-s sigspec | -signum | -sigspec] [pid | job]... or
kill -l [exitstatus]
[  FAILED  ] KDLCORBAPluginTest.VectorTest (3226 ms)
[----------] 1 test from KDLCORBAPluginTest (3227 ms total)
```

Not sure why this did not happen before with https://github.com/orocos/rtt_geometry/pull/29.